### PR TITLE
Add tox.ini for tox (http://tox.testrun.org/)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py26, py27, pypy, py33, py34, pypy3
+
+[testenv]
+deps =
+    colorclass
+    pytest
+commands = py.test {posargs:-v}


### PR DESCRIPTION
tox tests across multiple Python versions like Travis CI or Appveyor but
it's complementary, because you can run it locally and therefore can
test your code without having to commit and push to GitHub.

    $ pip install tox
    ...
    $ tox
    ...
      py26: commands succeeded
      py27: commands succeeded
      pypy: commands succeeded
      py33: commands succeeded
      py34: commands succeeded
      pypy3: commands succeeded
      congratulations :)