### PR TITLE
tox.ini: Report coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,5 @@ envlist = py26, py27, pypy, py33, py34, pypy3
 deps =
     colorclass
     pytest
-commands = py.test {posargs:-v}
+    pytest-cov
+commands = py.test {posargs:-v --cov=terminaltables --cov-report=term-missing}


### PR DESCRIPTION
```
$ tox -e py27
...
--------------------------------------------------------------- coverage: platform darwin, python 2.7.9-final-0 ----------------------------------------------------------------
Name             Stmts   Miss  Cover   Missing
----------------------------------------------
terminaltables     238     38    84%   29, 60-84, 89-98, 123-139, 225-231, 238-239, 249-250
```