### PR TITLE
Table footing, CI fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+requirements*.txt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -47,14 +48,6 @@ coverage.xml
 # Translations
 *.mo
 *.pot
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# Rope
-.ropeproject
 
 # Django stuff:
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ install:
 
 script:
   - tox
-  - (cd ./tests && ls .coverage.py34 .coverage.py33 .coverage.pypy3 .coverage.pypy .coverage.py27 .coverage.py26)
+  - tox -e combine py34 py33 pypy3 pypy py27 py26
 
 after_success:
-  - mv tests/.coverage* .
-  - coverage combine
+  - mv tests/.coverage .
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ script:
 
 after_success:
   - mv tests/.coverage .
-  - codecov
+  - codecov || true

--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,8 @@ Tested on Windows XP and Windows 10 technical preview.
    :target: https://pypi.python.org/pypi/terminaltables/
    :alt: Downloads
 
-`Quickstart`_
-=============
+Quickstart
+==========
 
 Install:
 
@@ -38,8 +38,8 @@ Install:
 
     pip install terminaltables
 
-`Example Implementations`_
-==========================
+Example Implementations
+=======================
 
 .. image:: https://github.com/Robpol86/terminaltables/raw/master/example.png?raw=true
    :alt: Example Scripts Screenshot
@@ -48,16 +48,16 @@ Source code for examples: `example1.py <https://github.com/Robpol86/terminaltabl
 `example2.py <https://github.com/Robpol86/terminaltables/blob/master/example2.py>`_, and
 `example3.py <https://github.com/Robpol86/terminaltables/blob/master/example3.py>`_
 
-`Usage`_
-========
+Usage
+=====
 
 The below usage information is for ``AsciiTable`` which uses simple ASCII characters for the table (e.g. ``-`` ``+``
 ``|``). Use ``SingleTable`` for `box drawing characters <http://en.wikipedia.org/wiki/Box-drawing_character>`_ instead.
 You may also use ``DoubleTable`` for double-lined box characters. All three tables have the same methods and properties
 and work on all platforms.
 
-`Simple Usage`_
----------------
+Simple Usage
+------------
 
 .. code:: python
 
@@ -118,8 +118,8 @@ relies on ``len()`` and other methods for calculating table borders. I suggest l
 `colorclass <https://github.com/Robpol86/colorclass>`_ for supporting colors in ``terminaltables`` since it handles
 color string lengths correctly.
 
-`Class Attributes`_
--------------------
+Class Attributes
+----------------
 
 You can instantiate with ``AsciiTable(table_data)`` or ``AsciiTable(table_data, 'Table Title')``. These are available
 after instantiating any table class.
@@ -138,8 +138,8 @@ Name                         Description/Notes
 ``padding_right``            Default is 1. Number of spaces to add to the right of the cell.
 ============================ ===============================================================================
 
-`Class Methods`_
-----------------
+Class Methods
+-------------
 
 These are regular methods available in either class.
 
@@ -149,8 +149,8 @@ Name                 Description/Notes
 ``column_max_width`` Takes one argument, column number (0 base). Returns The maximum size it will fit in the terminal without breaking the table. Takes other columns into account.
 ==================== ==============================================================================================================================================================
 
-`Class Properties`_
--------------------
+Class Properties
+----------------
 
 These are read-only properties after you instantiate either class. They are "real-time". You do not have to
 re-instantiate if you change any of the class attributes, including ``table_data``.
@@ -165,45 +165,45 @@ Name                  Description/Notes
 ``table_width``       Returns the width of the table including padding and borders.
 ===================== ====================================================================================
 
-`Changelog`_
-============
+Changelog
+=========
 
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
-`1.1.2 - 2015-05-26`_
----------------------
+1.2.0 - 2015-05-31
+------------------
 
-Added
+Added:
     * Bottom row separator.
 
-`1.1.1 - 2014-11-03`_
----------------------
+1.1.1 - 2014-11-03
+------------------
 
 Fixed
     * Python 2.7 64-bit terminal width bug on Windows.
 
-`1.1.0 - 2014-11-02`_
----------------------
+1.1.0 - 2014-11-02
+------------------
 
 Added:
     * Windows support.
     * Double-lined table.
 
-`1.0.2 - 2014-09-18`_
----------------------
+1.0.2 - 2014-09-18
+------------------
 
 Added
     * ``table_width`` and ``ok`` properties.
 
-`1.0.1 - 2014-09-12`_
----------------------
+1.0.1 - 2014-09-12
+------------------
 
 Added
     * Terminal width/height defaults for testing.
     * ``terminaltables.DEFAULT_TERMINAL_WIDTH``
     * ``terminaltables.DEFAULT_TERMINAL_HEIGHT``
 
-`1.0.0 - 2014-09-11`_
----------------------
+1.0.0 - 2014-09-11
+------------------
 
 * Initial release.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,4 +18,4 @@ test_script:
 
 after_test:
   - mv tests/.coverage .
-  - codecov
+  - codecov || exit /B 0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,11 +14,8 @@ build_script:
 
 test_script:
   - tox
-  - cd tests
-  - ps: ls .coverage.py34x64, .coverage.py34, .coverage.py33x64, .coverage.py33, .coverage.py27x64, .coverage.py27
-  - cd ..
+  - tox -e combine py34x64 py34 py33x64 py33 py27x64 py27
 
 after_test:
-  - mv tests/.coverage.* .
-  - coverage combine
+  - mv tests/.coverage .
   - codecov

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,0 @@
--r requirements.txt
-colorclass
-pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python
 """Setup script for the project."""
 
-import atexit
 import codecs
 import os
 import re
-import subprocess
-import sys
-from distutils.spawn import find_executable
 
 import setuptools
-from setuptools.command.test import test
 
 _PACKAGES = lambda: [os.path.join(r, s) for r, d, _ in os.walk(NAME_FILE) for s in d if s != '__pycache__']
 _VERSION_RE = re.compile(r"^__(version|author|license)__ = '([\w\.@]+)'$", re.MULTILINE)
@@ -41,17 +36,10 @@ KEYWORDS = 'Shell Bash ANSI ASCII terminal tables'
 NAME = 'terminaltables'
 NAME_FILE = NAME
 PACKAGE = False
+REQUIRES_INSTALL = ['colorclass']
+REQUIRES_TEST = ['pytest-cov']
+REQUIRES_ALL = REQUIRES_INSTALL + REQUIRES_TEST
 VERSION_FILE = os.path.join(NAME_FILE, '__init__.py') if PACKAGE else '{0}.py'.format(NAME_FILE)
-
-
-def _requires(path):
-    """Read requirements file."""
-    if not os.path.exists(os.path.join(HERE, path)):
-        return list()
-    file_handle = codecs.open(os.path.join(HERE, path), encoding='utf-8')
-    requirements = [i.strip() for i in file_handle if i[0] != '-']
-    file_handle.close()
-    return requirements
 
 
 def _safe_read(path, length):
@@ -64,62 +52,16 @@ def _safe_read(path, length):
     return contents
 
 
-class PyTest(test):
-    """Run tests with pytest."""
-
-    description = 'Run all tests.'
-    user_options = []
-    CMD = 'test'
-    TEST_ARGS = ['--cov-report', 'term-missing', '--cov', NAME_FILE, 'tests']
-
-    def finalize_options(self):
-        """Finalize options."""
-        overflow_args = sys.argv[sys.argv.index(self.CMD) + 1:]
-        test.finalize_options(self)
-        setattr(self, 'test_args', self.TEST_ARGS + overflow_args)
-        setattr(self, 'test_suite', True)
-
-    def run_tests(self):
-        """Run the tests."""
-        # Import here, cause outside the eggs aren't loaded.
-        pytest = __import__('pytest')
-        err_no = pytest.main(self.test_args)
-        sys.exit(err_no)
-
-
-class PyTestPdb(PyTest):
-    """Run tests with pytest and drop to debugger on test failure/errors."""
-
-    _ipdb = 'ipdb' if sys.version_info[:2] > (2, 6) else 'pdb'
-    description = 'Run all tests, drops to {0} upon unhandled exception.'.format(_ipdb)
-    CMD = 'testpdb'
-    TEST_ARGS = ['--{0}'.format(_ipdb), 'tests']
-
-
-class PyTestCovWeb(PyTest):
-    """Run the tests and open a web browser (OS X only) showing coverage information."""
-
-    description = 'Generates HTML report on test coverage.'
-    CMD = 'testcovweb'
-    TEST_ARGS = ['--cov-report', 'html', '--cov', NAME_FILE, 'tests']
-
-    def run_tests(self):
-        """Run the tests and then open."""
-        if find_executable('open'):
-            atexit.register(lambda: subprocess.call(['open', os.path.join(HERE, 'htmlcov', 'index.html')]))
-        PyTest.run_tests(self)
-
-
 ALL_DATA = dict(
     author_email='robpol86@gmail.com',
     classifiers=CLASSIFIERS,
-    cmdclass={PyTest.CMD: PyTest, PyTestPdb.CMD: PyTestPdb, PyTestCovWeb.CMD: PyTestCovWeb},
     description=DESCRIPTION,
-    install_requires=_requires('requirements.txt'),
+    install_requires=REQUIRES_INSTALL,
     keywords=KEYWORDS,
     long_description=_safe_read('README.rst', 15000),
     name=NAME,
-    tests_require=_requires('requirements-test.txt'),
+    requires=REQUIRES_INSTALL,
+    tests_require=REQUIRES_TEST,
     url='https://github.com/Robpol86/{0}'.format(NAME),
     zip_safe=True,
 )
@@ -128,7 +70,6 @@ ALL_DATA = dict(
 # noinspection PyTypeChecker
 ALL_DATA.update(dict(_VERSION_RE.findall(_safe_read(VERSION_FILE, 1500).replace('\r\n', '\n'))))
 ALL_DATA.update(dict(py_modules=[NAME_FILE]) if not PACKAGE else dict(packages=[NAME_FILE] + _PACKAGES()))
-ALL_DATA['requires'] = ALL_DATA['install_requires']
 
 
 if __name__ == '__main__':

--- a/terminaltables.py
+++ b/terminaltables.py
@@ -22,123 +22,19 @@ import os
 import re
 import struct
 import sys
-if os.name != 'nt':
+
+try:
     import fcntl
     import termios
-else:
-    import ctypes.wintypes
+except ImportError:
+    fcntl = None
+    termios = None
+
+from colorclass import _WindowsCSBI
 
 __author__ = '@Robpol86'
 __license__ = 'MIT'
-__version__ = '1.1.2'
-
-
-class _WindowsCSBI(object):
-    """Interface to Windows CONSOLE_SCREEN_BUFFER_INFO API/DLL calls. Gets info for stderr and stdout.
-
-    References:
-        https://code.google.com/p/colorama/issues/detail?id=47.
-        pytest's py project: py/_io/terminalwriter.py.
-
-    Class variables:
-    CSBI -- ConsoleScreenBufferInfo class/struct (not instance, the class definition itself) defined in _define_csbi().
-    HANDLE_STDERR -- GetStdHandle() return integer for stderr.
-    HANDLE_STDOUT -- GetStdHandle() return integer for stdout.
-    WINDLL -- my own loaded instance of ctypes.WinDLL.
-    """
-
-    CSBI = None
-    HANDLE_STDERR = None
-    HANDLE_STDOUT = None
-    WINDLL = ctypes.LibraryLoader(getattr(ctypes, 'WinDLL', None))
-
-    @staticmethod
-    def _define_csbi():
-        """Define structs and populates _WindowsCSBI.CSBI."""
-        if _WindowsCSBI.CSBI is not None:
-            return
-
-        class COORD(ctypes.Structure):
-            """Windows COORD structure. http://msdn.microsoft.com/en-us/library/windows/desktop/ms682119."""
-
-            _fields_ = [('X', ctypes.c_short), ('Y', ctypes.c_short)]
-
-        class SmallRECT(ctypes.Structure):
-            """Windows SMALL_RECT structure. http://msdn.microsoft.com/en-us/library/windows/desktop/ms686311."""
-
-            _fields_ = [('Left', ctypes.c_short), ('Top', ctypes.c_short), ('Right', ctypes.c_short),
-                        ('Bottom', ctypes.c_short)]
-
-        class ConsoleScreenBufferInfo(ctypes.Structure):
-            """Windows CONSOLE_SCREEN_BUFFER_INFO structure.
-
-            http://msdn.microsoft.com/en-us/library/windows/desktop/ms682093
-            """
-
-            _fields_ = [
-                ('dwSize', COORD),
-                ('dwCursorPosition', COORD),
-                ('wAttributes', ctypes.wintypes.WORD),
-                ('srWindow', SmallRECT),
-                ('dwMaximumWindowSize', COORD)
-            ]
-
-        _WindowsCSBI.CSBI = ConsoleScreenBufferInfo
-
-    @staticmethod
-    def initialize():
-        """Initialize the WINDLL resource and populated the CSBI class variable."""
-        _WindowsCSBI._define_csbi()
-        _WindowsCSBI.HANDLE_STDERR = _WindowsCSBI.HANDLE_STDERR or _WindowsCSBI.WINDLL.kernel32.GetStdHandle(-12)
-        _WindowsCSBI.HANDLE_STDOUT = _WindowsCSBI.HANDLE_STDOUT or _WindowsCSBI.WINDLL.kernel32.GetStdHandle(-11)
-        if _WindowsCSBI.WINDLL.kernel32.GetConsoleScreenBufferInfo.argtypes:
-            return
-
-        _WindowsCSBI.WINDLL.kernel32.GetStdHandle.argtypes = [ctypes.wintypes.DWORD]
-        _WindowsCSBI.WINDLL.kernel32.GetStdHandle.restype = ctypes.wintypes.HANDLE
-        _WindowsCSBI.WINDLL.kernel32.GetConsoleScreenBufferInfo.restype = ctypes.wintypes.BOOL
-        _WindowsCSBI.WINDLL.kernel32.GetConsoleScreenBufferInfo.argtypes = [
-            ctypes.wintypes.HANDLE, ctypes.POINTER(_WindowsCSBI.CSBI)
-        ]
-
-    @staticmethod
-    def get_info(handle):
-        """Get information about this current console window (for Microsoft Windows only).
-
-        Raises IOError if attempt to get information fails (if there is no console window).
-
-        Don't forget to call _WindowsCSBI.initialize() once in your application before calling this method.
-
-        Positional arguments:
-        handle -- either _WindowsCSBI.HANDLE_STDERR or _WindowsCSBI.HANDLE_STDOUT.
-
-        Returns:
-        Dictionary with different integer values. Keys are:
-            buffer_width -- width of the buffer (Screen Buffer Size in cmd.exe layout tab).
-            buffer_height -- height of the buffer (Screen Buffer Size in cmd.exe layout tab).
-            terminal_width -- width of the terminal window.
-            terminal_height -- height of the terminal window.
-            bg_color -- current background color (http://msdn.microsoft.com/en-us/library/windows/desktop/ms682088).
-            fg_color -- current text color code.
-        """
-        # Query Win32 API.
-        csbi = _WindowsCSBI.CSBI()
-        try:
-            if not _WindowsCSBI.WINDLL.kernel32.GetConsoleScreenBufferInfo(handle, ctypes.byref(csbi)):
-                raise IOError('Unable to get console screen buffer info from win32 API.')
-        except ctypes.ArgumentError:
-            raise IOError('Unable to get console screen buffer info from win32 API.')
-
-        # Parse data.
-        result = dict(
-            buffer_width=int(csbi.dwSize.X - 1),
-            buffer_height=int(csbi.dwSize.Y),
-            terminal_width=int(csbi.srWindow.Right - csbi.srWindow.Left),
-            terminal_height=int(csbi.srWindow.Bottom - csbi.srWindow.Top),
-            bg_color=int(csbi.wAttributes & 240),
-            fg_color=int(csbi.wAttributes % 16),
-        )
-        return result
+__version__ = '1.2.0'
 
 
 def _align_and_pad(input_, align, width, height, lpad, rpad):
@@ -274,7 +170,7 @@ class AsciiTable(object):
 
         self.inner_column_border = True
         self.inner_heading_row_border = True
-        self.inner_bottom_row_border = False
+        self.inner_footing_row_border = False
         self.inner_row_border = False
         self.justify_columns = dict()  # {0: 'right', 1: 'left', 2: 'center'}
         self.outer_border = True
@@ -388,7 +284,7 @@ class AsciiTable(object):
                                    self.CHAR_INTERSECT_RIGHT if self.outer_border else '')
                 final_table_data.append(row)
 
-            if i == indexes[-2] and self.inner_bottom_row_border:
+            if i == indexes[-2] and self.inner_footing_row_border:
                 row = _convert_row([self.CHAR_HORIZONTAL * w for w in column_widths],
                                    self.CHAR_INTERSECT_LEFT if self.outer_border else '',
                                    self.CHAR_INTERSECT_CENTER if self.inner_column_border else '',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,check,py{34,33,py3,py,27,26},py{34,33,27}x64
+envlist = flake8,check,requirements,py{34,33,py3,py,27,26},py{34,33,27,26}x64
 skip_missing_interpreters = True
 
 [testenv]
@@ -12,14 +12,30 @@ basepython =
     pypy: pypy
     py27x64: C:\Python27-x64\python.exe
     py27: python2.7
+    py26x64: C:\Python26-x64\python.exe
     py26: python2.6
 commands =
-    python setup.py test{posargs}
-    mv .coverage tests/.coverage.{envname}
+    ; python -c "import os; os.system('pip install -U pdbpp==0.8.1') if '--pdb' in '{posargs}' else None"
+    py.test --cov-report term-missing --cov terminaltables tests {posargs}
+    python -c "import os, shutil; shutil.move('.coverage', os.path.join('tests', '.coverage.{envname}'))"
 deps =
     -rrequirements-test.txt
-    py{34,33,py,27},py{34,33,27}x64: robpol86-pytest-ipdb
+usedevelop = True
 whitelist_externals = mv
+
+[testenv:requirements]
+basepython = python3.4
+commands =
+    python -c "import setup; open('requirements-test.txt', 'w').write('\n'.join(setup.REQUIRES_ALL))"
+deps =
+
+[testenv:combine]
+basepython = python3.4
+changedir = tests
+commands =
+    python -c "for f in '{posargs}'.split(): open('.coverage.' + f)"
+    coverage combine
+deps = coverage
 
 [testenv:check]
 basepython = python3.4
@@ -27,6 +43,7 @@ commands =
     python setup.py check --strict
     python setup.py check --strict -m
     python setup.py check --strict -s
+deps =
 
 [testenv:pylint]
 basepython = python3.4
@@ -38,7 +55,7 @@ basepython = python3.4
 commands = flake8
 deps =
     flake8
-    flake8-import-order
+    flake8-import-order==0.5
     flake8-pep257
     pep8-naming
 


### PR DESCRIPTION
Updated meta files to use the same ones in my other projects.

Renamed new footing api from "bottom" for consistency (heading and
footing, etc).

Removing hyperlinked titles in README, GitHub already does that anyway.

Moving requirements to setup.py file instead of external requirements
files.

Moving pdb/etc commands from setup.py into tox.

Pinning flake8-import-order since the latest version has a bug.

Using colorclass' WindowsCSBI instead of duplicate code here.