### PR TITLE
Created PorcelainTable class

### DIFF
--- a/terminaltables/__init__.py
+++ b/terminaltables/__init__.py
@@ -10,6 +10,7 @@ from terminaltables.ascii_table import AsciiTable  # noqa
 from terminaltables.github_table import GithubFlavoredMarkdownTable  # noqa
 from terminaltables.other_tables import DoubleTable  # noqa
 from terminaltables.other_tables import SingleTable  # noqa
+from terminaltables.other_tables import PorcelainTable  # noqa
 
 __author__ = '@Robpol86'
 __license__ = 'MIT'

--- a/terminaltables/other_tables.py
+++ b/terminaltables/other_tables.py
@@ -153,3 +153,20 @@ class DoubleTable(WindowsTableDouble):
     """
 
     pass
+
+
+class PorcelainTable(AsciiTable):
+    """ An AsciiTable stripped to a minimum, meant to be machine passable and roughly follow format set by git
+     --porcelain option (hence the name)
+     """
+
+    def __init__(self, table_data):
+        """
+        :param iter table_data: List (empty or list of lists of strings) representing the table.
+        """
+        super(PorcelainTable, self).__init__(table_data)
+
+        # Removes outer border, and inner footing and header row borders.
+        self.inner_footing_row_border = False
+        self.inner_heading_row_border = False
+        self.outer_border = False

--- a/terminaltables/other_tables.py
+++ b/terminaltables/other_tables.py
@@ -156,7 +156,7 @@ class DoubleTable(WindowsTableDouble):
 
 
 class PorcelainTable(AsciiTable):
-    """ An AsciiTable stripped to a minimum.
+    """An AsciiTable stripped to a minimum.
 
     Meant to be machine passable and roughly follow format set by git --porcelain option (hence the name).
 

--- a/terminaltables/other_tables.py
+++ b/terminaltables/other_tables.py
@@ -156,14 +156,19 @@ class DoubleTable(WindowsTableDouble):
 
 
 class PorcelainTable(AsciiTable):
-    """ An AsciiTable stripped to a minimum, meant to be machine passable and roughly follow format set by git
-     --porcelain option (hence the name)
-     """
+    """ An AsciiTable stripped to a minimum.
+
+    Meant to be machine passable and roughly follow format set by git --porcelain option (hence the name).
+
+    :ivar iter table_data: List (empty or list of lists of strings) representing the table.
+    """
 
     def __init__(self, table_data):
-        """
+        """Constructor.
+
         :param iter table_data: List (empty or list of lists of strings) representing the table.
         """
+        # Porcelain table won't support title since it has no outer birders.
         super(PorcelainTable, self).__init__(table_data)
 
         # Removes outer border, and inner footing and header row borders.

--- a/tests/test_all_tables_e2e/test_porcelain_table.py
+++ b/tests/test_all_tables_e2e/test_porcelain_table.py
@@ -1,0 +1,60 @@
+"""PorcelainTable end to end testing."""
+
+from terminaltables import PorcelainTable
+
+
+def test_single_line():
+    """Test single-lined cells."""
+    table_data = [
+        ['Name', 'Color', 'Type'],
+        ['Avocado', 'green', 'nut'],
+        ['Tomato', 'red', 'fruit'],
+        ['Lettuce', 'green', 'vegetable'],
+        ['Watermelon', 'green']
+    ]
+    table = PorcelainTable(table_data)
+    table.justify_columns[0] = 'left'
+    table.justify_columns[1] = 'center'
+    table.justify_columns[2] = 'right'
+    actual = table.table
+
+    expected = (
+        ' Name       | Color |      Type \n'
+        ' Avocado    | green |       nut \n'
+        ' Tomato     |  red  |     fruit \n'
+        ' Lettuce    | green | vegetable \n'
+        ' Watermelon | green |           '
+     )
+    assert actual == expected
+
+
+def test_multi_line():
+    """Test multi-lined cells."""
+    table_data = [
+        ['Show', 'Characters'],
+        ['Rugrats', 'Tommy Pickles, Chuckie Finster, Phillip DeVille, Lillian DeVille, Angelica Pickles,\nDil Pickles'],
+        ['South Park', 'Stan Marsh, Kyle Broflovski, Eric Cartman, Kenny McCormick']
+    ]
+    table = PorcelainTable(table_data)
+
+    # Test defaults.
+    actual = table.table
+    expected = (
+        ' Show       | Characters                                                                          \n'
+        ' Rugrats    | Tommy Pickles, Chuckie Finster, Phillip DeVille, Lillian DeVille, Angelica Pickles, \n'
+        '            | Dil Pickles                                                                         \n'
+        ' South Park | Stan Marsh, Kyle Broflovski, Eric Cartman, Kenny McCormick                          '
+    )
+    assert actual == expected
+
+
+    # Justify right.
+    table.justify_columns = {1: 'right'}
+    actual = table.table
+    expected = (
+        ' Show       |                                                                          Characters \n'
+        ' Rugrats    | Tommy Pickles, Chuckie Finster, Phillip DeVille, Lillian DeVille, Angelica Pickles, \n'
+        '            |                                                                         Dil Pickles \n'
+        ' South Park |                          Stan Marsh, Kyle Broflovski, Eric Cartman, Kenny McCormick '
+    )
+    assert actual == expected

--- a/tests/test_all_tables_e2e/test_porcelain_table.py
+++ b/tests/test_all_tables_e2e/test_porcelain_table.py
@@ -24,7 +24,7 @@ def test_single_line():
         ' Tomato     |  red  |     fruit \n'
         ' Lettuce    | green | vegetable \n'
         ' Watermelon | green |           '
-     )
+    )
     assert actual == expected
 
 
@@ -46,7 +46,6 @@ def test_multi_line():
         ' South Park | Stan Marsh, Kyle Broflovski, Eric Cartman, Kenny McCormick                          '
     )
     assert actual == expected
-
 
     # Justify right.
     table.justify_columns = {1: 'right'}


### PR DESCRIPTION
Added a class that'll emulate `git --porcelain` option, useful for stuff (at least I'll use it :smile: ).
```
from terminaltables.other_tables import PorcelainTable

table_data = [
    ['Heading1', 'Heading2'],
    ['row1 column1', 'row1 column2'],
    ['row2 column1', 'row2 column2'],
    ['row3 column1', 'row3 column2']
]
table = PorcelainTable(table_data)
print (table.table)

 Heading1     | Heading2     
 row1 column1 | row1 column2 
 row2 column1 | row2 column2 
 row3 column1 | row3 column2 
```