### PR TITLE
Include license and tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include tox.ini
+include example*.py
+
+graft tests


### PR DESCRIPTION
The terms of the MIT license requires all copies of the source include the license text.

Fixes #66